### PR TITLE
Ease up Mongoid dependency in Searchkick.relation?

### DIFF
--- a/lib/searchkick.rb
+++ b/lib/searchkick.rb
@@ -329,7 +329,7 @@ module Searchkick
     if klass.respond_to?(:current_scope)
       !klass.current_scope.nil?
     else
-      klass.is_a?(Mongoid::Criteria) || !Mongoid::Threaded.current_scope(klass).nil?
+      defined?(Mongoid) && (klass.is_a?(Mongoid::Criteria) || !Mongoid::Threaded.current_scope(klass).nil?)
     end
   end
 


### PR DESCRIPTION
The method will fail with `NameError` if an app doesn't have `mongoid` in its Gemfile:

```
=> #<NameError: uninitialized constant Searchkick::Mongoid

      klass.is_a?(Mongoid::Criteria) || !Mongoid::Threaded.current_scope(klass).nil?
                  ^^^^^^^>
```